### PR TITLE
Install Lmod from source

### DIFF
--- a/accre-internal/Singularity.accre.internal.base
+++ b/accre-internal/Singularity.accre.internal.base
@@ -8,7 +8,7 @@ Include: yum
 
 %help
   Base container for internal ACCRE use with Lmod support
-  To access the software stack make sure to bind mount /accre/arch and /accre/common
+  To access the software stack make sure to bind mount /accre and /cvmfs
 
 %environment
   export MODULEPATH_ROOT=/accre/arch/easybuild/modules/all
@@ -37,4 +37,4 @@ Include: yum
   rm -rf ${LMOD_VERSION}.tar.gz Lmod-${LMOD_VERSION}
 
   # Setup CVMFS binds for ACCRE software stack
-  mkdir -p /accre/arch /accre/common
+  mkdir -p /accre /cvmfs

--- a/accre-internal/Singularity.accre.internal.base
+++ b/accre-internal/Singularity.accre.internal.base
@@ -7,15 +7,34 @@ Include: yum
   Maintainer Eric Appelt
 
 %help
-  Base container for internal ACCRE use with LMod support
-  To access the software stack make sure to bind mount /cvmfs and /accre
+  Base container for internal ACCRE use with Lmod support
+  To access the software stack make sure to bind mount /accre/arch and /accre/common
 
-%files
-  lmod.sh /etc/profile.d/lmod.sh
-  lmod-7.8.8-1.x86_64.rpm /lmod-7.8.8-1.x86_64.rpm
+%environment
+  export MODULEPATH_ROOT=/accre/arch/easybuild/modules/all
+  export MODULEPATH=$MODULEPATH_ROOT/Core:$MODULEPATH_ROOT/BinDist
+  export LMOD_SHORT_TIME=86400
+  export LMOD_ADMIN_FILE=/accre/common/lmod/etc/admin.lmod
+  export LMOD_RC=/accre/common/lmod/etc/lmodrc.lua
+  source /usr/local/lmod/lmod/init/bash
 
 %post
   yum -y install wget bzip2 gcc tcl tk tar procps git
+  
+  # Install Lmod
+  export LMOD_VERSION=8.1.7
   yum -y install http://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
-  yum -y install lua lua-devel lua-posix lua-filesystem
-  yum -y install /lmod-7.8.8-1.x86_64.rpm
+  yum -y install lua lua-filesystem lua-posix lua-term lua-devel
+  yum -y install make
+  wget https://github.com/TACC/Lmod/archive/${LMOD_VERSION}.tar.gz
+  tar xzf ${LMOD_VERSION}.tar.gz
+  cd Lmod-${LMOD_VERSION}
+  ./configure --with-spiderCacheDir=/accre/arch/lmod/cache \
+              --with-updateSystemFn=/accre/arch/lmod/cache/timestamp.lmod \
+              --with-tcl=no
+  make install
+  cd ..
+  rm -rf ${LMOD_VERSION}.tar.gz Lmod-${LMOD_VERSION}
+
+  # Setup CVMFS binds for ACCRE software stack
+  mkdir -p /accre/arch /accre/common


### PR DESCRIPTION
Lmod is now installed from sources at image build time. Here are the advantages:
- Fully independent on the availability of a rpm package
- Ability to use the spider cache since the cache files paths must be set at compile time
- Increased configuration flexibility

I recommend executing the generated image with `--cleanenv` to prevent inheriting Lmod environment variables set on the host. 